### PR TITLE
feat: add workflow to update generated Go code from Conjure IR

### DIFF
--- a/.github/workflows/update-conjure-api.yml
+++ b/.github/workflows/update-conjure-api.yml
@@ -3,28 +3,17 @@ name: Update Conjure API
 on:
   # This is triggered by https://github.com/nominal-io/scout/blob/main/.github/workflows/npm-publish.yml
   workflow_dispatch:
-  # Dispatch to grafana-plugin when changes are merged to main
-  push:
-    branches:
-      - main
-    paths:
-      - "**/*.conjure.go"
-      - "go.mod"
-      - "go.sum"
 
 permissions:
   contents: write
   pull-requests: write
-  actions: read
 
 concurrency:
   group: update-conjure-api
   cancel-in-progress: true
 
 jobs:
-  # Job 1: Regenerate Go code from Conjure IR (only on workflow_dispatch)
   update-and-check:
-    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -163,37 +152,8 @@ jobs:
           if [ "${{ steps.check_changes.outputs.has_changes }}" == "true" ]; then
             echo "### Update Complete" >> $GITHUB_STEP_SUMMARY
             echo "Generated Go code has been updated and a PR has been created/updated." >> $GITHUB_STEP_SUMMARY
-            echo "Once the PR is merged to main, grafana-plugin will be notified to update its dependency." >> $GITHUB_STEP_SUMMARY
+            echo "Downstream repos (e.g., grafana-plugin) will be updated via Renovate." >> $GITHUB_STEP_SUMMARY
           else
             echo "### No Changes" >> $GITHUB_STEP_SUMMARY
             echo "The generated Go code is already up to date with the latest Conjure IR." >> $GITHUB_STEP_SUMMARY
           fi
-
-  # Job 2: Dispatch to grafana-plugin when changes are merged to main
-  dispatch-to-grafana-plugin:
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Get Token for cross-repo dispatch
-        id: get_actions_token
-        uses: nominal-io/workflow-application-token-action@d17e3a9a36850ea89f35db16c1067dd2b68ee343 # v4.0.1
-        with:
-          application_id: ${{ secrets.NOMBOT_APP_ID }}
-          application_private_key: ${{ secrets.NOMBOT_PRIVATE_KEY }}
-          organization: "nominal-io"
-          permissions: "actions: write, contents: read"
-          revoke_token: true
-
-      - name: Trigger dispatch for grafana-plugin repository
-        uses: benc-uk/workflow-dispatch@e2e5e9a103e331dad343f381a29e654aea3cf8fc # 1.2.0
-        with:
-          workflow: update-nominal-api-go.yml
-          repo: nominal-io/grafana-plugin
-          token: ${{ steps.get_actions_token.outputs.token }}
-          ref: main
-
-      - name: Summary
-        run: |
-          echo "### Dispatch Complete" >> $GITHUB_STEP_SUMMARY
-          echo "Triggered grafana-plugin to update its nominal-api-go dependency." >> $GITHUB_STEP_SUMMARY
-          echo "Commit: \`${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically regenerates the Go client code when scout releases a new version. The workflow is triggered via `workflow_dispatch` from scout's `npm-publish.yml`.

**What it does:**
- Clones the scout repository
- Compiles the Conjure IR (`./gradlew scout-service-api:compileIr`)
- Regenerates Go code using `./godelw conjure`
- Creates/updates a PR on the `nombot/update-conjure-api` branch (with @leundai as reviewer)

Downstream repos (e.g., grafana-plugin) will be updated via Renovate rather than direct dispatch from this workflow.

## Updates since last revision

- **Simplified to single trigger**: Removed the `push` trigger and `dispatch-to-grafana-plugin` job. Grafana-plugin updates are now handled by Renovate (see companion PR #47).
- **Removed dispatch secrets requirement**: No longer needs `NOMBOT_APP_ID` or `NOMBOT_PRIVATE_KEY` since we're not dispatching to other repos.

## Review & Testing Checklist for Human

- [ ] **Go version**: The workflow specifies `go-version: "1.25"` but this version doesn't exist yet. Verify this matches what's actually needed (go.mod also says 1.25.0 which seems incorrect)
- [ ] **Secrets availability**: Verify `NOMBOT_CLASSIC_PERSONAL_ACCESS_TOKEN` secret exists in nominal-api-go with permissions for contents:write and pull-requests:write
- [ ] **Scout repo access**: The workflow clones scout via public HTTPS without authentication. Verify scout is publicly accessible or add authentication token
- [ ] **Companion PRs**: This is part of a 2-repo automation chain. Merge in order:
  1. Scout PR: https://github.com/nominal-io/scout/pull/10230 (adds dispatch trigger)
  2. grafana-plugin PR: https://github.com/nominal-io/grafana-plugin/pull/47 (adds Renovate for dependency updates)
  3. This PR

### Test Plan
1. Merge companion PRs first (scout and grafana-plugin)
2. Merge this PR
3. Go to Actions tab > "Update Conjure API" workflow
4. Click "Run workflow" to trigger manually
5. Verify it clones scout, compiles IR, generates code, and creates a PR in nominal-api-go

### Notes
- Pattern follows existing galaxy `bump-scout.yml` workflow
- The automation chain: scout releases → nominal-api-go regenerates Go code → Renovate detects changes and updates grafana-plugin

Link to Devin run: https://app.devin.ai/sessions/40486a867bb840638acd8932dab8e93b
Requested by: Leo Galindo-Frias (@Leundai)