### PR TITLE
fix: add Apache 2.0 license and NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,3 @@
+nominal-api-go
+This product includes software developed by Nominal, Inc.
+Copyright (c) 2026 Nominal, Inc.


### PR DESCRIPTION
## Summary
- Replaces existing license (or adds new) with Apache License 2.0 (Copyright 2026 Nominal, Inc)
- Adds NOTICE file per Apache 2.0 requirements

Ref: LEG-73

🤖 Generated with [Claude Code](https://claude.com/claude-code)